### PR TITLE
fix two grpc goroutine leaks

### DIFF
--- a/ingress_client.go
+++ b/ingress_client.go
@@ -487,12 +487,13 @@ func (c *IngressClient) emit(batch []*loggregator_v2.Envelope, close bool) error
 
 	err := c.sender.Send(&loggregator_v2.EnvelopeBatch{Batch: batch})
 	if err != nil {
+		c.sender.CloseAndRecv()
 		c.sender = nil
 		return err
 	}
 
 	if close {
-		return c.sender.CloseSend()
+		c.sender.CloseAndRecv()
 	}
 
 	return nil


### PR DESCRIPTION
Relevant documentation I just added: https://godoc.org/google.golang.org/grpc#ClientConn.NewStream

I also [updated the proto-gen-go generator to generate godoc about this](https://github.com/golang/protobuf/pull/600#pullrequestreview-119480895). If you build the latest generator and re-generate your protos you should get that change.