### PR TITLE
v2_ingress example: sleep before closing client

### DIFF
--- a/examples/v2_ingress/main.go
+++ b/examples/v2_ingress/main.go
@@ -50,5 +50,7 @@ func main() {
 		client.EmitTimer("loop_times", startTime, time.Now())
 	}
 
+	time.Sleep(2 * time.Second)
+	
 	client.CloseSend()
 }


### PR DESCRIPTION
In the v2_ingress example we should sleep a little bit to ensure that
the metrics are sent before we close the client.