### PR TITLE
Add support for representing tags as structured data in syslog msg

### DIFF
--- a/rpc/loggregator_v2/syslog.go
+++ b/rpc/loggregator_v2/syslog.go
@@ -81,24 +81,23 @@ func (m *Envelope) Syslog(opts ...SyslogOption) ([][]byte, error) {
 		messages := make([][]byte, 0, len(metrics))
 		for name, g := range metrics {
 			msg := m.basicSyslogMessage(c, priority)
-			msg.StructuredData = append(msg.StructuredData,
-				rfc5424.StructuredData{
-					ID: gaugeStructuredDataID,
-					Parameters: []rfc5424.SDParam{
-						{
-							Name:  "name",
-							Value: name,
-						},
-						{
-							Name:  "value",
-							Value: strconv.FormatFloat(g.GetValue(), 'g', -1, 64),
-						},
-						{
-							Name:  "unit",
-							Value: g.GetUnit(),
-						},
+			msg.StructuredData = append(msg.StructuredData, rfc5424.StructuredData{
+				ID: gaugeStructuredDataID,
+				Parameters: []rfc5424.SDParam{
+					{
+						Name:  "name",
+						Value: name,
+					},
+					{
+						Name:  "value",
+						Value: strconv.FormatFloat(g.GetValue(), 'g', -1, 64),
+					},
+					{
+						Name:  "unit",
+						Value: g.GetUnit(),
 					},
 				},
+			},
 			)
 			d, err := msg.MarshalBinary()
 			if err != nil {
@@ -109,24 +108,23 @@ func (m *Envelope) Syslog(opts ...SyslogOption) ([][]byte, error) {
 		return messages, nil
 	case *Envelope_Counter:
 		msg := m.basicSyslogMessage(c, priority)
-		msg.StructuredData = append(msg.StructuredData,
-			rfc5424.StructuredData{
-				ID: counterStructuredDataID,
-				Parameters: []rfc5424.SDParam{
-					{
-						Name:  "name",
-						Value: m.GetCounter().GetName(),
-					},
-					{
-						Name:  "total",
-						Value: fmt.Sprint(m.GetCounter().GetTotal()),
-					},
-					{
-						Name:  "delta",
-						Value: fmt.Sprint(m.GetCounter().GetDelta()),
-					},
+		msg.StructuredData = append(msg.StructuredData, rfc5424.StructuredData{
+			ID: counterStructuredDataID,
+			Parameters: []rfc5424.SDParam{
+				{
+					Name:  "name",
+					Value: m.GetCounter().GetName(),
+				},
+				{
+					Name:  "total",
+					Value: fmt.Sprint(m.GetCounter().GetTotal()),
+				},
+				{
+					Name:  "delta",
+					Value: fmt.Sprint(m.GetCounter().GetDelta()),
 				},
 			},
+		},
 		)
 		d, err := msg.MarshalBinary()
 		if err != nil {
@@ -147,24 +145,23 @@ func (m *Envelope) Syslog(opts ...SyslogOption) ([][]byte, error) {
 		return [][]byte{d}, nil
 	case *Envelope_Timer:
 		msg := m.basicSyslogMessage(c, priority)
-		msg.StructuredData = append(msg.StructuredData,
-			rfc5424.StructuredData{
-				ID: timerStructuredDataID,
-				Parameters: []rfc5424.SDParam{
-					{
-						Name:  "name",
-						Value: m.GetTimer().GetName(),
-					},
-					{
-						Name:  "start",
-						Value: fmt.Sprint(m.GetTimer().GetStart()),
-					},
-					{
-						Name:  "stop",
-						Value: fmt.Sprint(m.GetTimer().GetStop()),
-					},
+		msg.StructuredData = append(msg.StructuredData, rfc5424.StructuredData{
+			ID: timerStructuredDataID,
+			Parameters: []rfc5424.SDParam{
+				{
+					Name:  "name",
+					Value: m.GetTimer().GetName(),
+				},
+				{
+					Name:  "start",
+					Value: fmt.Sprint(m.GetTimer().GetStart()),
+				},
+				{
+					Name:  "stop",
+					Value: fmt.Sprint(m.GetTimer().GetStop()),
 				},
 			},
+		},
 		)
 		d, err := msg.MarshalBinary()
 		if err != nil {
@@ -200,12 +197,12 @@ func (m *Envelope) basicSyslogMessage(
 		for k, v := range tags {
 			params = append(params, rfc5424.SDParam{Name: k, Value: v})
 		}
-		msg.StructuredData = append(msg.StructuredData,
-			rfc5424.StructuredData{
+		msg.StructuredData = []rfc5424.StructuredData{
+			{
 				ID:         tagsStructuredDataID,
 				Parameters: params,
 			},
-		)
+		}
 	}
 
 	return msg

--- a/rpc/loggregator_v2/syslog_test.go
+++ b/rpc/loggregator_v2/syslog_test.go
@@ -231,6 +231,9 @@ var _ = Describe("Syslog", func() {
 			env.SourceId = "some-source-id"
 			env.InstanceId = "some-instance-id"
 			env.Timestamp = int64(time.Hour)
+			env.Tags = map[string]string{
+				"namespace": "test-ns",
+			}
 
 			d, err := env.Syslog(
 				loggregator_v2.WithSyslogHostname("some-hostname"),
@@ -238,8 +241,8 @@ var _ = Describe("Syslog", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(d).To(ConsistOf(
-				[]byte(`<14>1 1970-01-01T01:00:00+00:00 some-hostname some-source-id some-instance-id - [gauge@47450 name="cpu" value="0.23" unit="percentage"] `+"\n"),
-				[]byte(`<14>1 1970-01-01T01:00:00+00:00 some-hostname some-source-id some-instance-id - [gauge@47450 name="memory" value="5423" unit="bytes"] `+"\n"),
+				[]byte(`<14>1 1970-01-01T01:00:00+00:00 some-hostname some-source-id some-instance-id - [tags@47450 namespace="test-ns"][gauge@47450 name="cpu" value="0.23" unit="percentage"] `+"\n"),
+				[]byte(`<14>1 1970-01-01T01:00:00+00:00 some-hostname some-source-id some-instance-id - [tags@47450 namespace="test-ns"][gauge@47450 name="memory" value="5423" unit="bytes"] `+"\n"),
 			))
 		})
 


### PR DESCRIPTION
When envelopes have tags, they will be represented as follows:

```
<14>1 1970-01-01T01:00:00+00:00 some-hostname some-source-id some-instance-id - [tags@47450 namespace="test-ns"][gauge@47450 name="memory" value="5423" unit="bytes"] 
```

For Context:
@jasonkeene 
@ahevenor 