### PR TITLE
Use /v8 import path for go mod v2+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the Loggregator API.
 
 This repository should be imported as:
 
-`import loggregator "code.cloudfoundry.org/go-loggregator"`
+`import loggregator "code.cloudfoundry.org/go-loggregator/v8"`
 
 ## Examples
 

--- a/conversion/benchmark/benchmark_test.go
+++ b/conversion/benchmark/benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/container_metric_test.go
+++ b/conversion/container_metric_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/counter_event_test.go
+++ b/conversion/counter_event_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/end_to_end_test.go
+++ b/conversion/end_to_end_test.go
@@ -3,8 +3,8 @@ package conversion_test
 import (
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/envelope_test.go
+++ b/conversion/envelope_test.go
@@ -3,8 +3,8 @@ package conversion_test
 import (
 	"fmt"
 
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/error_test.go
+++ b/conversion/error_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/http_test.go
+++ b/conversion/http_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/instance_id_test.go
+++ b/conversion/instance_id_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"

--- a/conversion/log_message_test.go
+++ b/conversion/log_message_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/tov1.go
+++ b/conversion/tov1.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/conversion/tov1_test.go
+++ b/conversion/tov1_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/conversion/tov2.go
+++ b/conversion/tov2.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 

--- a/conversion/tov2_test.go
+++ b/conversion/tov2_test.go
@@ -3,7 +3,7 @@ package conversion_test
 import (
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"

--- a/conversion/value_metric_test.go
+++ b/conversion/value_metric_test.go
@@ -1,8 +1,8 @@
 package conversion_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/conversion"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/conversion"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"

--- a/envelope_stream_connector.go
+++ b/envelope_stream_connector.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	gendiodes "code.cloudfoundry.org/go-diodes"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/envelope_stream_connector_test.go
+++ b/envelope_stream_connector_test.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 
-	"code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/examples/envelope_stream_connector/main.go
+++ b/examples/envelope_stream_connector/main.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"os"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
 )
 
 var allSelectors = []*loggregator_v2.Selector{

--- a/examples/rlp_gateway/main.go
+++ b/examples/rlp_gateway/main.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"os"
 
-	"code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/golang/protobuf/jsonpb"
 )
 

--- a/examples/runtime_stats/main.go
+++ b/examples/runtime_stats/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/runtimeemitter"
 )
 
 func main() {

--- a/examples/v1_ingress/main.go
+++ b/examples/v1_ingress/main.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/cloudfoundry/dropsonde"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/v1"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	v1 "code.cloudfoundry.org/go-loggregator/v8/v1"
 )
 
 func main() {

--- a/examples/v2_ingress/main.go
+++ b/examples/v2_ingress/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator"
+	"code.cloudfoundry.org/go-loggregator/v8"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module code.cloudfoundry.org/go-loggregator
+module code.cloudfoundry.org/go-loggregator/v8
 
 go 1.12
 

--- a/ingress_client.go
+++ b/ingress_client.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 )
 
 // IngressOption is the type of a configurable client option.

--- a/ingress_client_test.go
+++ b/ingress_client_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
-	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/runtimeemitter"
 	"golang.org/x/net/context"
 
 	. "github.com/onsi/ginkgo"

--- a/one_to_one_envelope_batch_diode.go
+++ b/one_to_one_envelope_batch_diode.go
@@ -1,7 +1,7 @@
 package loggregator
 
 import (
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	gendiodes "code.cloudfoundry.org/go-diodes"
 )

--- a/pulseemitter/counter_metric.go
+++ b/pulseemitter/counter_metric.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/golang/protobuf/proto"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
 )
 
 // MetricOption defines a function type that can be used to configure tags for

--- a/pulseemitter/counter_metric_test.go
+++ b/pulseemitter/counter_metric_test.go
@@ -3,9 +3,9 @@ package pulseemitter_test
 import (
 	"sync"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/pulseemitter"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/pulseemitter"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pulseemitter/gauge_metric.go
+++ b/pulseemitter/gauge_metric.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"sync/atomic"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/pulseemitter/gauge_metric_test.go
+++ b/pulseemitter/gauge_metric_test.go
@@ -1,8 +1,8 @@
 package pulseemitter_test
 
 import (
-	"code.cloudfoundry.org/go-loggregator/pulseemitter"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/pulseemitter"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pulseemitter/pulse_emitter.go
+++ b/pulseemitter/pulse_emitter.go
@@ -3,7 +3,7 @@ package pulseemitter
 import (
 	"time"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
 )
 
 // LogClient is the client used by PulseEmitter to emit metrics. This would

--- a/pulseemitter/pulse_emitter_test.go
+++ b/pulseemitter/pulse_emitter_test.go
@@ -3,8 +3,8 @@ package pulseemitter_test
 import (
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/pulseemitter"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/pulseemitter"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/rlp_gateway_client.go
+++ b/rlp_gateway_client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"github.com/golang/protobuf/jsonpb"
 	"golang.org/x/net/context"
 )

--- a/rlp_gateway_client_test.go
+++ b/rlp_gateway_client_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"golang.org/x/net/context"
 
-	"code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 )
 
 var _ = Describe("RlpGatewayClient", func() {

--- a/rpc/loggregator_v2/syslog_test.go
+++ b/rpc/loggregator_v2/syslog_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 	"code.cloudfoundry.org/rfc5424"
 
 	. "github.com/onsi/ginkgo"

--- a/runtimeemitter/runtime_emitter.go
+++ b/runtimeemitter/runtime_emitter.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator"
+	"code.cloudfoundry.org/go-loggregator/v8"
 )
 
 // Emitter will emit a gauge with runtime stats via the sender on the given

--- a/runtimeemitter/runtime_emitter_test.go
+++ b/runtimeemitter/runtime_emitter_test.go
@@ -4,9 +4,9 @@ import (
 	"runtime"
 	"time"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
-	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/runtimeemitter"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/servers_test.go
+++ b/servers_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"code.cloudfoundry.org/go-loggregator/v8/rpc/loggregator_v2"
 )
 
 type testIngressServer struct {

--- a/v1/client.go
+++ b/v1/client.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	loggregator "code.cloudfoundry.org/go-loggregator"
+	loggregator "code.cloudfoundry.org/go-loggregator/v8"
 
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/cloudfoundry/sonde-go/events"

--- a/v1/client_test.go
+++ b/v1/client_test.go
@@ -3,9 +3,9 @@ package v1_test
 import (
 	"time"
 
-	"code.cloudfoundry.org/go-loggregator"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator"
-	"code.cloudfoundry.org/go-loggregator/v1"
+	"code.cloudfoundry.org/go-loggregator/v8"
+	loggregator_v2 "code.cloudfoundry.org/go-loggregator/v8"
+	"code.cloudfoundry.org/go-loggregator/v8/v1"
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/cloudfoundry/sonde-go/events"
 


### PR DESCRIPTION
Related to new go module requirements: https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher