### PR TITLE
Add dependabot and a simple pipeline

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Gomod updates
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,24 @@
+name: Build and test Go
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+
+      - name: Build
+        run: |
+          source .envrc
+          go build ./...
+
+      - name: Test
+        run: | 
+          source .envrc
+          go test -v ./...


### PR DESCRIPTION
Enabled dependabot to keep dependencies up to date.

The simple pipeline helps to validate that the changes don't break anything.

This can be tested locally using https://github.com/nektos/act by running `act pull_request`.  