### PR TITLE
Fix: remove unneeded tools.go

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
-)


### PR DESCRIPTION
As of v2.8.2, Ginkgo "now includes a tools.go file in the root directory of the ginkgo package. This should allow modules that simply go get github.com/onsi/ginkgo/v2 to also pull in the CLI dependencies. This obviates the need for consumers of Ginkgo to have their own tools.go file and makes it simpler to ensure that the version of the ginkgo CLI being used matches the version of the library."