### PR TITLE
fix: Require go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/go-loggregator/v9
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/go-diodes v0.0.0-20180905200951-72629b5276e3

--- a/v1/client.go
+++ b/v1/client.go
@@ -7,7 +7,7 @@
 package v1
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"strconv"
 	"time"
@@ -50,7 +50,7 @@ type Client struct {
 func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		tags:   make(map[string]string),
-		logger: log.New(ioutil.Discard, "", 0),
+		logger: log.New(io.Discard, "", 0),
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
google.golang.org/grpc@1.59.0 requires at least go1.19, so in order to bump to that version, which is the latest version, we need to require at least go1.19 as well.