### PR TITLE
Bump Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/go-loggregator/v10
 
-go 1.25.8
+go 1.26
 
 require (
 	code.cloudfoundry.org/go-diodes v0.0.0-20260209061029-a81ffbc46978


### PR DESCRIPTION
Bumps the `go` directive to 1.26; Go 1.25 reached EOL on 2026-08-19, so we were shipping an EOL Go toolchain. `go mod tidy` run; vendored trees refreshed where applicable. CI / golangci-lint should be green.

🤖 Generated with Claude Code (Opus, claude-opus-latest). Human-reviewed before submitting.